### PR TITLE
add 查询接口时 创建人(creater)字段

### DIFF
--- a/app/assets/pages/api-edit-page/store.js
+++ b/app/assets/pages/api-edit-page/store.js
@@ -1,5 +1,6 @@
 import ajax from 'xhr-plus';
 import { message } from 'antd';
+import { userInfo } from '../../utils/utils';
 
 export default {
   namespace: 'apiEditModel',
@@ -49,6 +50,7 @@ export default {
      */
     *saveAPI({ api }, { call }) {
       const url = api._id ? `/api/apis/${api._id}` : '/api/apis';
+      api.creater = userInfo();
       try {
         const { status, errMsg } = yield call(ajax, {
           url,

--- a/app/assets/pages/collection-page/index.jsx
+++ b/app/assets/pages/collection-page/index.jsx
@@ -78,6 +78,10 @@ class Collection extends React.PureComponent {
       return moment(updatedAt).format('YYYY-MM-DD HH:mm:ss');
     },
   }, {
+    title: '创建人',
+    dataIndex: 'creater',
+    key: 'creater',
+  }, {
     title: '操作',
     dataIndex: 'operation',
     key: 'operation',

--- a/app/assets/utils/utils.js
+++ b/app/assets/utils/utils.js
@@ -139,6 +139,13 @@ export function tpl(str, vars) {
   return result;
 }
 
+export function userInfo() {
+  const {
+    user,
+  } = window.context;
+  return user;
+}
+
 export function isOwner(data) {
   const {
     user,

--- a/app/controller/api.js
+++ b/app/controller/api.js
@@ -46,12 +46,14 @@ exports.apisIndex = async function (ctx) {
     projectId: 1,
     updatedAt: 1,
     createdAt: 1,
+    creater: 1,
   }).sort({ createdAt: -1 }).lean();
 
   apis = apis.map(item => ({
     ...item,
     projectName: projectMap[item.projectId] ? projectMap[item.projectId].name : '',
     projectDesc: projectMap[item.projectId] ? projectMap[item.projectId].desc : '',
+    creater: item.creater ? item.creater.cname : '',
   }));
 
   this.body = {
@@ -146,7 +148,7 @@ exports.apisNew = async function (ctx) {
       };
       errMsg = '';
     } else {
-      errMsg = '接口集中已存在路径规则为 ${newApi.url} 的接口';
+      errMsg = `接口集中已存在路径规则为 ${newApi.url} 的接口`;
     }
   }
 

--- a/app/model/api.js
+++ b/app/model/api.js
@@ -21,6 +21,7 @@ module.exports = app => {
     responses: { type: Array },
     requestSchema: { type: Object },
     responseSchema: { type: Object },
+    creater: { type: Object },
   }, {
     timestamps: true,
   });


### PR DESCRIPTION
主要实现方式：
app/assets/utils/utils.js 在这里增加了一个获取当前User工具类(直接从window.context 获取）、
然后在 app/assets/pages/api-edit-page/store.js 中获取 到用户信息，然后传值进入数据库。
